### PR TITLE
修复了导致“未将对象引用设置到对象的实例”的BUG

### DIFF
--- a/src/Parse12306/Program.cs
+++ b/src/Parse12306/Program.cs
@@ -190,11 +190,11 @@ namespace Parse12306
                 List<string> typeList = dateObj.Properties().Select(p => p.Name).ToList();
                 foreach (string type in typeList)
                 {
-					//type = "C,D,G,K,O,T,Z", we just get high speed trains. It means "C,D,G"
-					// User may also comment the 'if' clause or modify the "CDG" to your own demand.
-					if ("CDG".Contains(type))
-					{
-						JArray dataArray = (JArray)dateObj[type];
+                    //type = "C,D,G,K,O,T,Z", we just get high speed trains. It means "C,D,G"
+                    // User may also comment the 'if' clause or modify the "CDG" to your own demand.
+                    if ("CDG".Contains(type))
+                    {
+                        JArray dataArray = (JArray)dateObj[type];
                         foreach (JObject data in dataArray)
                         {
                             string trainCode = data["station_train_code"].ToString(); //D1(北京-沈阳)
@@ -222,8 +222,8 @@ namespace Parse12306
                     List<string> outputList = new List<string>();
                     foreach (Train train in trainList)
                     {
-						String tmp = train.ToBaseCSV();
-						if (tmp != String.Empty) outputList.Add(tmp);
+                        String tmp = train.ToBaseCSV();
+                        if (tmp != String.Empty) outputList.Add(tmp);
                     }
                     WriteFile(GetStepFile(STEP_4, date + ".txt"), string.Join("\r\n", outputList.ToArray()));
                     Console.WriteLine("Output " + date + ".txt");
@@ -643,8 +643,8 @@ namespace Parse12306
 
         public string ToBaseCSV()
         {
-			if (StartStation == null || EndStation == null) return String.Empty;
-			List<string> list = new List<string>();
+            if (StartStation == null || EndStation == null) return String.Empty;
+            List<string> list = new List<string>();
             list.Add(Type);
             list.Add(Name);
             list.Add(TrainNo);

--- a/src/Parse12306/Program.cs
+++ b/src/Parse12306/Program.cs
@@ -190,10 +190,11 @@ namespace Parse12306
                 List<string> typeList = dateObj.Properties().Select(p => p.Name).ToList();
                 foreach (string type in typeList)
                 {
-                    //type = "C,D,G,K,O,T,Z", we just get high speed trains. It means "C,D,G"
-                    if ("CDG".Contains(type))
-                    {
-                        JArray dataArray = (JArray)dateObj[type];
+					//type = "C,D,G,K,O,T,Z", we just get high speed trains. It means "C,D,G"
+					// User may also comment the 'if' clause or modify the "CDG" to your own demand.
+					if ("CDG".Contains(type))
+					{
+						JArray dataArray = (JArray)dateObj[type];
                         foreach (JObject data in dataArray)
                         {
                             string trainCode = data["station_train_code"].ToString(); //D1(北京-沈阳)
@@ -221,7 +222,8 @@ namespace Parse12306
                     List<string> outputList = new List<string>();
                     foreach (Train train in trainList)
                     {
-                        outputList.Add(train.ToBaseCSV());
+						String tmp = train.ToBaseCSV();
+						if (tmp != String.Empty) outputList.Add(tmp);
                     }
                     WriteFile(GetStepFile(STEP_4, date + ".txt"), string.Join("\r\n", outputList.ToArray()));
                     Console.WriteLine("Output " + date + ".txt");
@@ -641,7 +643,8 @@ namespace Parse12306
 
         public string ToBaseCSV()
         {
-            List<string> list = new List<string>();
+			if (StartStation == null || EndStation == null) return String.Empty;
+			List<string> list = new List<string>();
             list.Add(Type);
             list.Add(Name);
             list.Add(TrainNo);


### PR DESCRIPTION
非常感谢您提供的代码！但是我在尝试从“只抓取高铁动车”改为“抓取所有车次”后，会报出“未将对象引用设置到对象的实例”的异常。经本人调试，问题可能来源于从12306上下载到的train_list.js中会包含空项，遂在代码中加入了两处非空判断语句，问题解决。